### PR TITLE
force Navigation bar to be shown after phone validation on viewDidAppear

### DIFF
--- a/ChatApp/ConvListViewController.m
+++ b/ChatApp/ConvListViewController.m
@@ -33,6 +33,10 @@
 
 - (void)viewDidAppear:(BOOL)animated {
     NSLog(@"viewDidAppear");
+   
+    [super viewWillAppear:animated];
+    [[self navigationController] setNavigationBarHidden:NO animated:YES];
+ 
 }
 
 - (void)didReceiveMemoryWarning {


### PR DESCRIPTION
Add

``` objective-c
- (void)viewDidAppear:(BOOL)animated {
    NSLog(@"viewDidAppear");

    [super viewWillAppear:animated];
    [[self navigationController] setNavigationBarHidden:NO animated:YES];

}
```

to force Navigation bar to be shown after phone validation on viewDidAppear
